### PR TITLE
fix(Types): fix received component prop types

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,8 +10,8 @@ const passThru = <TArgs extends any>(args: TArgs) => args;
 const hooked = <Props extends Object, HookRet, HookArgs = Props>(
   hook: (args: HookArgs) => HookRet,
   extractArgs: (props: Props) => HookArgs = passThru as any,
-) => (WrappedComponent: React.ComponentType<Props & HookRet>) => (
-  props: Props,
-) => <WrappedComponent {...props} {...hook(extractArgs(props))} />;
+) => (WrappedComponent: React.ComponentType<Props>) => (props: Props) => (
+  <WrappedComponent {...props} {...hook(extractArgs(props))} />
+);
 
 export default hooked;


### PR DESCRIPTION
The received component should not have HookRet as part of its initial props. HookRet should only be added to the resulting component